### PR TITLE
Allow External Postgres

### DIFF
--- a/polyaxon/requirements.yaml
+++ b/polyaxon/requirements.yaml
@@ -2,6 +2,7 @@ dependencies:
   - name: postgresql
     version: 0.8.7
     repository: https://kubernetes-charts.storage.googleapis.com/
+    condition: postgresql.enabled
   - name: rabbitmq
     version: 0.6.15
     repository: https://kubernetes-charts.storage.googleapis.com/

--- a/polyaxon/templates/partials/_db.tpl
+++ b/polyaxon/templates/partials/_db.tpl
@@ -9,10 +9,18 @@ db config
 - name: POLYAXON_DB_PASSWORD
   valueFrom:
     secretKeyRef:
+{{ if .Values.postgresql.enabled }}
       name: {{ template "postgresql.fullname" . }}
+{{ else }}
+      name: {{ template "polyaxon.fullname" . }}-postgres-secret
+{{- end}}
       key: postgres-password
 - name: POLYAXON_DB_HOST
-  value: {{ template "postgresql.fullname" . }}
+{{ if .Values.postgresql.enabled }}
+  value: {{  template "postgresql.fullname" . }}
+{{ else }}
+  value: {{ .Values.postgresql.externalPostgresHost | quote }}
+{{ end }}
 - name: POLYAXON_DB_PORT
   value: "5432"
 - name: POLYAXON_DB_CONN_MAX_AGE

--- a/polyaxon/templates/partials/_k8s.tpl
+++ b/polyaxon/templates/partials/_k8s.tpl
@@ -14,6 +14,12 @@ k8s config
   value: {{ template "polyaxon.fullname" . }}-secret
 - name: POLYAXON_K8S_RABBITMQ_SECRET_NAME
   value: {{ template "rabbitmq.fullname" . }}
+- name: POLYAXON_K8S_DB_SECRET_NAME
+{{- if .Values.postgresql.enabled }}
+  value: {{ template "postgres.fullname" . }}
+{{- else }}
+value: {{ template "polyaxon.fullname" . }}-postgres-secret
+{{- end}}
 {{- if .Values.k8s.authorisation }}
 - name: POLYAXON_K8S_AUTHORISATION
   valueFrom:

--- a/polyaxon/templates/partials/_k8s.tpl
+++ b/polyaxon/templates/partials/_k8s.tpl
@@ -18,7 +18,7 @@ k8s config
 {{- if .Values.postgresql.enabled }}
   value: {{ template "postgres.fullname" . }}
 {{- else }}
-value: {{ template "polyaxon.fullname" . }}-postgres-secret
+  value: {{ template "polyaxon.fullname" . }}-postgres-secret
 {{- end}}
 {{- if .Values.k8s.authorisation }}
 - name: POLYAXON_K8S_AUTHORISATION

--- a/polyaxon/templates/secrets.yaml
+++ b/polyaxon/templates/secrets.yaml
@@ -42,3 +42,23 @@ data:
   auth-bitbucket-client-id: {{ default "" .Values.auth.bitbucket.clientId | b64enc | quote }}
   auth-bitbucket-client-secret: {{ default "" .Values.auth.bitbucket.clientSecret | b64enc | quote }}
   {{ end }}
+---
+{{ if not .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "polyaxon.fullname" . }}-postgres-secret
+labels:
+    app: {{ template "polyaxon.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    type: {{ .Values.types.core }}
+type: Opaque
+data:
+  {{ if .Values.postgresql.postgresPassword }}
+  postgres-password:  {{ .Values.postgresql.postgresPassword | b64enc | quote }}
+  {{ else }}
+  postgres-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+{{- end -}}

--- a/polyaxon/values.yaml
+++ b/polyaxon/values.yaml
@@ -316,10 +316,14 @@ hooks:
   imagePullPolicy: IfNotPresent
 
 postgresql:
-  imageTag: 9.6.1
+  ## Whether to deploy a postgres server in-cluster. To use an external postgres instance, set enabled to False and configure 
+  ## externalPostgresHost with your existing postgres hostname. postgresUser, postgresPassword and postgresDatabase still apply.
+  enabled: True
   postgresUser: polyaxon
   postgresPassword: polyaxon
   postgresDatabase: polyaxon
+  externalPostgresHost:
+  imageTag: 9.6.1
   persistence:
     enabled: false
     size: 2Gi


### PR DESCRIPTION
Allow specifying an already existing Postgres instance host name in the chart.
If specified, the in-cluster Postgres instance will not be deployed.