### PR TITLE
[WIP] Add support to private registry spec as a dict with 3 fields: host,user,password

### DIFF
--- a/ci/test-config.yml
+++ b/ci/test-config.yml
@@ -167,9 +167,11 @@ environment: testing
 
 privateRegistries:
   - host: "my.registry.com"
-    username: "_json_key"
+    user: "_json_key"
     password: '{"type": "service_account", "project_id": "my_project", "private_key_id": "ajshvasjhqweqetquytqut17253871238", "private_key": "-----BEGIN PRIVATE KEY-----\nASBHJASJDASBDJAJHSBDJB/sfbdj12231\sdfsdfs/sfsdf12323/34r342/asdasd\n-----END PRIVATE KEY-----\n", "client_email": "email@email.com", "client_id": "12345", "auth_uri": "https://accounts.google.com/o/oauth2/auth", "token_uri": "https://oauth2.googleapis.com/token", "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs", "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/asdajhdvah123712378183"}'
 
   - host: another.registry.com
-    username: name
+    user: name
     password: pass
+
+  - "user-foo:tKV9DYsxrwfiY85KYpf9N4GZ@cloud.somewhere.io:5000"

--- a/ci/test-config.yml
+++ b/ci/test-config.yml
@@ -164,3 +164,12 @@ persistence:
       hostPath: "/tmp/outputs"
 
 environment: testing
+
+privateRegistries:
+  - host: "my.registry.com"
+    username: "_json_key"
+    password: '{"type": "service_account", "project_id": "my_project", "private_key_id": "ajshvasjhqweqetquytqut17253871238", "private_key": "-----BEGIN PRIVATE KEY-----\nASBHJASJDASBDJAJHSBDJB/sfbdj12231\sdfsdfs/sfsdf12323/34r342/asdasd\n-----END PRIVATE KEY-----\n", "client_email": "email@email.com", "client_id": "12345", "auth_uri": "https://accounts.google.com/o/oauth2/auth", "token_uri": "https://oauth2.googleapis.com/token", "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs", "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/asdajhdvah123712378183"}'
+
+  - host: another.registry.com
+    username: name
+    password: pass

--- a/ci/validate/values2.yml
+++ b/ci/validate/values2.yml
@@ -84,5 +84,12 @@ integrations:
     - url: https://hooks.slack.com/services/sdlkfjsdlk/lkjsdlkfjdklsjf2
 
 privateRegistries:
-  - "foo:secret@cloud.foobar.io:5000"
+  - host: "my.registry.com"
+    username: "_json_key"
+    password: '{"type": "service_account", "project_id": "my_project", "private_key_id": "ajshvasjhqweqetquytqut17253871238", "private_key": "-----BEGIN PRIVATE KEY-----\nASBHJASJDASBDJAJHSBDJB/sfbdj1223"}'
 
+  - host: "another.registry.com"
+    username: "myname"
+    password: "mypassword"
+  
+  - "user:password@foo.bar.registry.com"

--- a/ci/validate/values2.yml
+++ b/ci/validate/values2.yml
@@ -85,11 +85,11 @@ integrations:
 
 privateRegistries:
   - host: "my.registry.com"
-    username: "_json_key"
+    user: "_json_key"
     password: '{"type": "service_account", "project_id": "my_project", "private_key_id": "ajshvasjhqweqetquytqut17253871238", "private_key": "-----BEGIN PRIVATE KEY-----\nASBHJASJDASBDJAJHSBDJB/sfbdj1223"}'
 
   - host: "another.registry.com"
-    username: "myname"
+    user: "myname"
     password: "mypassword"
-  
+
   - "user:password@foo.bar.registry.com"

--- a/ci/validate/values3.yml
+++ b/ci/validate/values3.yml
@@ -97,6 +97,14 @@ integrations:
     - url: https://hooks.slack.com/services/sdfdfdsfsdf/sdflsdklfj
     - url: https://hooks.slack.com/services/sdlkfjsdlk/lkjsdlkfjdklsjf2
 
-privateRegistries:
-  - "foo:secret@cloud.foobar.io:5000"
 
+privateRegistries:
+  - host: "my.registry.com"
+    username: "_json_key"
+    password: '{"type": "service_account", "project_id": "my_project", "private_key_id": "ajshvasjhqweqetquytqut17253871238", "private_key": "-----BEGIN PRIVATE KEY-----\nASBHJASJDASBDJAJHSBDJB/sfbdj1223"}'
+
+  - host: "another.registry.com"
+    username: "myname"
+    password: "mypassword"
+
+  - "user:password@foo.bar.registry.com"

--- a/ci/validate/values3.yml
+++ b/ci/validate/values3.yml
@@ -100,11 +100,11 @@ integrations:
 
 privateRegistries:
   - host: "my.registry.com"
-    username: "_json_key"
+    user: "_json_key"
     password: '{"type": "service_account", "project_id": "my_project", "private_key_id": "ajshvasjhqweqetquytqut17253871238", "private_key": "-----BEGIN PRIVATE KEY-----\nASBHJASJDASBDJAJHSBDJB/sfbdj1223"}'
 
   - host: "another.registry.com"
-    username: "myname"
+    user: "myname"
     password: "mypassword"
 
   - "user:password@foo.bar.registry.com"

--- a/polyaxon/templates/secrets.yaml
+++ b/polyaxon/templates/secrets.yaml
@@ -51,7 +51,7 @@ data:
   {{- end }}
   {{- if .Values.privateRegistries }}
   {{- range $index, $val := .Values.privateRegistries }}
-  POLYAXON_PRIVATE_REGISTRY_{{ $index }}: {{ $val | quote | b64enc | quote }}
+  POLYAXON_PRIVATE_REGISTRY_{{ $index }}: {{ toJson $val | b64enc | quote }}
   {{- end }}
   {{- end }}
 ---

--- a/polyaxon/templates/secrets.yaml
+++ b/polyaxon/templates/secrets.yaml
@@ -51,7 +51,7 @@ data:
   {{- end }}
   {{- if .Values.privateRegistries }}
   {{- range $index, $val := .Values.privateRegistries }}
-  POLYAXON_PRIVATE_REGISTRY_{{ $index }}: {{ $val | b64enc | quote }}
+  POLYAXON_PRIVATE_REGISTRY_{{ $index }}: {{ $val | quote | b64enc | quote }}
   {{- end }}
   {{- end }}
 ---


### PR DESCRIPTION
@mouradmourafiq As discussed in the slack I tried to implement the idea to change private registry spec from a single string to 3 fields. Parsing seems working for modified `value1.yml`, `value2.yml`.
I also changed the parsing on the [polyaxon side](https://github.com/vfdev-5/polyaxon/commit/8ceab4195ce778536f131060d18821c9021ed623).

In CI, the following command fails:
```
helm install --name polyaxon-test --namespace polyaxon ./polyaxon/ -f ./ci/test-config.yml
```

What do you think about this ?

PS: I did not manage to test this on my GCP cluster.