### PR TITLE
Add hosts to ingress spec when tls not enabled

### DIFF
--- a/polyaxon/templates/ingress/ing.yaml
+++ b/polyaxon/templates/ingress/ing.yaml
@@ -41,15 +41,18 @@ spec:
   {{- end }}  {{- /* end loop */ -}}
   {{- else }}  {{- /* else if tls.enabled */ -}}
   rules:
-  - http:
-      paths:
-      - path: /
-        backend:
-          serviceName: {{ template "polyaxon.fullname" . }}-api
-          servicePort: {{ .Values.api.service.externalPort }}
-      - path: /ws
-        backend:
-          serviceName: {{ template "polyaxon.fullname" . }}-api
-          servicePort: {{ .Values.streams.service.externalPort }}
-  {{- end -}} {{- /* end if tls.enabled */ -}}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: {{ $fullName }}-api
+            servicePort: {{ $.Values.api.service.externalPort }}
+        - path: /ws
+          backend:
+            serviceName: {{ $fullName }}-api
+            servicePort: {{ $.Values.streams.service.externalPort }}
+  {{- end }} {{- /* end range ingress.hosts */ -}}
+  {{- end }} {{- /* end if tls.enabled */ -}}
 {{- end }}

--- a/polyaxon/values.yaml
+++ b/polyaxon/values.yaml
@@ -19,6 +19,8 @@ ingress:
     ingress.kubernetes.io/proxy-send-timeout: "600"
     ingress.kubernetes.io/send-timeout: "600"
     ingress.kubernetes.io/proxy-body-size: 4G
+  hosts:
+    - chart-example.local
   resources:
     limits:
       cpu: 10m


### PR DESCRIPTION
The simplest way to achieve https://github.com/polyaxon/polyaxon/issues/278
@mouradmourafiq please let me know if this breaks backward compatibility and what the best way to go about preserving that would be and I'll update it accordingly.