### PR TITLE
fix: secrets labels and docker-registry secrets

### DIFF
--- a/polyaxon/templates/secrets.yaml
+++ b/polyaxon/templates/secrets.yaml
@@ -63,7 +63,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "polyaxon.fullname" . }}-postgres-secret
-labels:
+  labels:
     app: {{ template "polyaxon.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
@@ -83,7 +83,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "polyaxon.fullname" . }}-registry-secret
-labels:
+  labels:
     app: {{ template "polyaxon.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: "{{ .Release.Name }}"
@@ -91,6 +91,6 @@ labels:
     type: {{ .Values.types.core }}
 type: Opaque
 data:
-  registry-user:  {{ (index .Values "docker-registry").auth.user }}
-  registry-password: {{ (index .Values "docker-registry").auth.password }}
+  registry-user:  {{ (index .Values "docker-registry").auth.user | b64enc | quote }}
+  registry-password: {{ (index .Values "docker-registry").auth.password | b64enc | quote }}
 {{- end -}}


### PR DESCRIPTION
This PR fixes the labels of postgres and docker-registry secrets. And it fixes the encoding of the docker-registry secrets.