### PR TITLE
Fix broken secrets separators

### DIFF
--- a/polyaxon/templates/secrets.yaml
+++ b/polyaxon/templates/secrets.yaml
@@ -57,8 +57,9 @@ data:
   {{- if .Values.reposAccessToken }}
   POLYAXON_REPOS_ACCESS_TOKEN: {{ default "" .Values.reposAccessToken | b64enc | quote }}
   {{- end }}
----
+
 {{ if not .Values.postgresql.enabled }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -71,14 +72,15 @@ metadata:
     type: {{ .Values.types.core }}
 type: Opaque
 data:
-  {{ if .Values.postgresql.postgresPassword }}
+  {{- if .Values.postgresql.postgresPassword }}
   postgres-password:  {{ .Values.postgresql.postgresPassword | b64enc | quote }}
-  {{ else }}
+  {{- else }}
   postgres-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
+  {{- end -}}
 {{- end -}}
----
+
 {{ if (index .Values "docker-registry").auth.password }}
+---
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
if there is no docker-registry auth set the extra --- gets added to the Postgres secret which generates an error. This might be an issue more places

![image](https://user-images.githubusercontent.com/3949285/51968538-7b98e480-2472-11e9-86ff-89509e8b7e07.png)
