### PR TITLE
Make sure to quote TPU related values

### DIFF
--- a/polyaxon/templates/cm.yaml
+++ b/polyaxon/templates/cm.yaml
@@ -68,10 +68,10 @@ data:
   POLYAXON_K8S_GPU_RESOURCE_KEY: "alpha.kubernetes.io/nvidia-gpu"
   {{- end }}
   {{- if .Values.tpuTensorflowVersion }}
-  POLYAXON_K8S_TPU_TF_VERSION: {{ .Values.tpuTensorflowVersion }}
+  POLYAXON_K8S_TPU_TF_VERSION: {{ .Values.tpuTensorflowVersion | quote }}
   {{- end }}
   {{- if .Values.tpuResourceKey }}
-  POLYAXON_K8S_TPU_RESOURCE_KEY: {{ .Values.tpuResourceKey }}
+  POLYAXON_K8S_TPU_RESOURCE_KEY: {{ .Values.tpuResourceKey | quote }}
   {{- end }}
   # Secrets and ConfigMaps
   POLYAXON_REFS_SECRETS: {{ toJson .Values.secretRefs | quote }}


### PR DESCRIPTION
Make sure to quote TPU related values. In my environment, I could run `helm upgrade` successfully after tweaking double quotations. This PR is to avoid this tweaking.

* operation logs at failure

```
$ cat polyaxon/polyaxon-config.yml | egrep ^tpu                                                                         
tpuTensorflowVersion: "1.12"
tpuResourceKey: "cloud-tpus.google.com/preemptible-v2"

$ helm upgrade polyaxon polyaxon/polyaxon -f polyaxon/polyaxon-config.yml --version 0.3.9 --namespace polyaxon 
2019/02/20 11:43:16 Warning: Merging destination map for chart 'polyaxon'. The destination item 'builds' is a table and ignoring the source 'builds' as it has a non-table value of: <nil>
2019/02/20 11:43:16 Warning: Merging destination map for chart 'polyaxon'. The destination item 'core' is a table and ignoring the source 'core' as it has a non-table value of: <nil>
2019/02/20 11:43:16 Warning: Merging destination map for chart 'polyaxon'. The destination item 'experiments' is a table and ignoring the source 'experiments' as it has a non-table value of: <nil>
2019/02/20 11:43:16 Warning: Merging destination map for chart 'polyaxon'. The destination item 'jobs' is a table and ignoring the source 'jobs' as it has a non-table value of: <nil>
2019/02/20 11:43:16 Warning: Merging destination map for chart 'polyaxon'. The destination item 'tensorboards' is a table and ignoring the source 'tensorboards' as it has a non-table value of: <nil>
Error: UPGRADE FAILED: v1.ConfigMap.Data: ReadString: expects " or n, but found 1, error found in #10 byte of ...|VERSION":1.12,"POLYA|..., bigger context ...|om/preemptible-v2","POLYAXON_K8S_TPU_TF_VERSION":1.12,"POLYAXON_LIB_LATEST_VERSION":"0.0.5","POLYAXO|...
```

* operation logs at success

```
$ cat polyaxon/polyaxon-config.yml | egrep ^tpu
tpuTensorflowVersion: "\"1.12\""
tpuResourceKey: "\"cloud-tpus.google.com/preemptible-v2\""

$ helm upgrade polyaxon polyaxon/polyaxon -f polyaxon/polyaxon-config.yml --version 0.3.9 --namespace polyaxon
2019/02/20 12:51:43 Warning: Merging destination map for chart 'polyaxon'. The destination item 'jobs' is a table and ignoring the source 'jobs' as it has a non-table value of: <nil>
2019/02/20 12:51:43 Warning: Merging destination map for chart 'polyaxon'. The destination item 'tensorboards' is a table and ignoring the source 'tensorboards' as it has a non-table value of: <nil>
2019/02/20 12:51:43 Warning: Merging destination map for chart 'polyaxon'. The destination item 'builds' is a table and ignoring the source 'builds' as it has a non-table value of: <nil>
2019/02/20 12:51:43 Warning: Merging destination map for chart 'polyaxon'. The destination item 'core' is a table and ignoring the source 'core' as it has a non-table value of: <nil>
2019/02/20 12:51:43 Warning: Merging destination map for chart 'polyaxon'. The destination item 'experiments' is a table and ignoring the source 'experiments' as it has a non-table value of: <nil>
Release "polyaxon" has been upgraded. Happy Helming!
...
```