### PR TITLE
Fix ingress template for GKE comptibility

### DIFF
--- a/polyaxon/templates/ing.yaml
+++ b/polyaxon/templates/ing.yaml
@@ -27,7 +27,7 @@ spec:
   - host: {{ .Values.ingress.hostName | quote }}
     http:
       paths:
-      - path: /
+      - path: /*
         backend:
           serviceName: {{ $fullName }}-api
           servicePort: {{ $.Values.api.service.externalPort }}


### PR DESCRIPTION
I had problems analog to the issue linked below and the same solution worked for me aswell. I hope this does not conflict with any other implementation.
https://github.com/jetstack/kube-lego/issues/115#issuecomment-290235071