### PR TITLE
Make chart revision optional in config map

### DIFF
--- a/polyaxon/templates/cm.yaml
+++ b/polyaxon/templates/cm.yaml
@@ -195,7 +195,9 @@ data:
   POLYAXON_LIB_LATEST_VERSION: "0.0.5"
   POLYAXON_CHART_VERSION: {{ .Chart.Version | quote }}
   POLYAXON_CHART_IS_UPGRADE: {{ .Release.IsUpgrade | quote }}
+  {{- if .Values.includeChartRevison }}
   POLYAXON_CHART_REVISION: {{ .Release.Revision | quote }}
+  {{- end }}
   # Auth
   {{- if .Values.ldap.enabled }}
   POLYAXON_AUTH_LDAP: "true"

--- a/polyaxon/values.yaml
+++ b/polyaxon/values.yaml
@@ -51,6 +51,9 @@ timeZone: 'UTC'
 adminViewEnabled: true
 encryptionSecret:
 
+# Include helm chart relase revision
+includeChartRevision: true
+
 dirs:
   nvidia:
     lib: ""  # e.g. "/usr/lib/nvidia-384"


### PR DESCRIPTION
Including the chart revision in the config map causes issues with helm-diff, these changes make it optional.